### PR TITLE
[#RAG-12] Updates to Readme, and .env

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,6 @@ CODEBASE_LANGUAGE="ruby"
 # The suffixes of code files to parse as a comma-separates list.
 # For example: ".rb" or ".ex,.exs"
 CODE_SUFFIXES=".rb,"
+
+CHUNK_SIZE=3500
+CHUNK_OVERLAP=875

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ wheels/
 share/python-wheels/
 .qnd/
 .venv
+.venv-rag-time/
+.codebase
+.files
 phoenix/
 phoenix_db_jina-embeddings-v2-base-code-local/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Simple Chat UI to chat about a private codebase using LLMs locally.
 1. Create a Python virtual environment and activate it:
 
    ```bash
-   python3 -m venv .venv && source .venv/bin/activate
+   python3 -m venv .venv-rag-time && source .venv-rag-time/bin/activate
    ```
 
 2. Install Python dependencies:
@@ -68,3 +68,9 @@ Simple Chat UI to chat about a private codebase using LLMs locally.
 ## Make it your own
 
 Modify the `.env` file to run the chat bot on your codebase and language.
+
+## Ask Questions
+
+"The file "....ex" is missing a module comment. Can you create one that helps new team members understand what it does, and how it works?"
+
+"Given the following Mission, can you please explain what files I should change, and how I can implement the changes?"


### PR DESCRIPTION
The environment name \`.venv\` is a bit generic. let’s change this to “`.venv-rag-time`" in the README and the .gitignore

https://bitcrowd.atlassian.net/browse/RAG-12